### PR TITLE
object responses + CI

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,2 @@
+node_modules*
+coverage

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,18 @@
+{
+  "node": true,
+  "mocha": true,
+  "indent": 2,
+  "newcap": true,
+  "quotmark": "single",
+  "undef": true,
+  "lastsemic": true,
+  "eqeqeq": true,
+  "esnext": true,
+  "expr": true,
+  "asi": true,
+  "unused": true,
+  "eqnull": true,
+  "globals"      : {
+    "Promise"   : true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # svp-reststub: server for creating REST stubs for testing
 
+[![Circle CI](https://circleci.com/gh/stonevalleypartners/svp-reststub.svg?style=svg&circle-token=47d0cca2b56df13e2b84e34eceb9b18c28ae4a7a)](https://circleci.com/gh/stonevalleypartners/svp-reststub)
+
 ## install
 
 `npm install --save-dev git@github.com:stonevalleypartners/svp-reststub.git`
@@ -15,3 +17,4 @@ return rest.start(port)
     rest.addRoute(string, path, func);
   })
 ```
+

--- a/Stub.js
+++ b/Stub.js
@@ -10,7 +10,7 @@ function Stub(log){
     logger: this.log
   }));
   this.app.use(bodyParser.json())
-  this.server = http.Server(this.app);
+  this.server = http.createServer(this.app);
   this.router = express.Router();
   this.app.use(this.router);
   this.routes = {};

--- a/Stub.js
+++ b/Stub.js
@@ -1,6 +1,5 @@
 var express = require('express');
 var http = require('http');
-var lodash = require('lodash');
 var bodyParser = require('body-parser');
 var portFinder = require('svp-portfinder');
 
@@ -15,10 +14,12 @@ function Stub(log){
   this.router = express.Router();
   this.app.use(this.router);
   this.routes = {};
-};
+  this.responses = {};
+}
 
 Stub.prototype.start = function(_port){
-  return _port ? Promise.resolve(_port) : portFinder()
+  var portPromise = _port ? Promise.resolve(_port) : portFinder();
+  return portPromise
     .then((port) => {
       return new Promise((resolve, reject) => {
         this.server.listen(port);
@@ -35,24 +36,47 @@ Stub.prototype.start = function(_port){
   });
 };
 
-Stub.prototype.addRoute = function(name,path, fun){
+Stub.prototype.addRoute = function(name, path, fun){
   var self = this;
-  return new Promise ( function(resolve,reject) {
-    if ( ! self.routes[name] ) self.routes[name]=[];
-    self.log.info({routes: self.routes, path: path});
-    self.router.all(path, function(req,res,next) {
+  if ( ! self.routes[name] ) self.routes[name]=[];
+  self.log.info({routes: self.routes, path: path});
+  self.router.all(path, function(req,res) {
+    var call = {
+      method: req.method,
+      params: req.params,
+      body: req.body,
+      query: req.query,
+    };
+    self.routes[name].push(call);
+    if ( fun ) fun(req,res);
+    else res.status(200).json({name: 'rest stub route:'+name});
+  });
+  return Promise.resolve();
+};
+
+Stub.prototype.setResponse = function(name, path, obj, status) {
+  this.routes[name] = this.routes[name] || [];
+
+  // if this hasn't been previously configured; add the route
+  if(!this.responses[name]) {
+    this.router.all(path, (req, res) => {
       var call = {
         method: req.method,
         params: req.params,
         body: req.body,
         query: req.query,
       };
-      self.routes[name].push(call);
-      if ( fun ) fun(req,res);
-      else res.status(200).json({name: 'rest stub route:'+name});
+      this.routes[name].push(call);
+      var r = this.responses[name];
+      return res.status(r.status).json(r.obj);
     });
-    resolve();
-  });
+  }
+
+  // store the response
+  this.responses[name] = {
+    obj: obj,
+    status: status || 200
+  };
 };
 
 Stub.prototype.stop = function(){

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,16 @@
+machine:
+  node:
+    version: stable
+
+dependencies:
+  pre:
+    - npm install -g npm@latest
+
+general:
+  artifacts:
+    - npm-debug.log
+    - mocha.log
+    - coverage
+test:
+  override:
+    - npm test

--- a/package.json
+++ b/package.json
@@ -2,9 +2,15 @@
   "name": "svp-reststub",
   "version": "0.0.1",
   "description": "",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stonevalleypartners/svp-reststub",
+    "version": "1.0.0"
+  },
   "main": "Stub.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "pretest": "jshint .",
+    "test": "istanbul cover node_modules/.bin/_mocha -- -R spec test"
   },
   "author": "Alex Linden Levy",
   "license": "ISC",
@@ -20,6 +26,9 @@
     "bunyan": "^1.5.1",
     "chai": "^3.3.0",
     "chai-as-promised": "^5.1.0",
+    "istanbul": "^0.3.22",
+    "jshint": "^2.8.0",
+    "mocha": "^2.3.3",
     "request-promise": "^0.4.3"
   }
 }


### PR DESCRIPTION
- add support for jshint & coverage
- configure circleCI
- adds `Stub.setResponse` method to set the response to send to a client
- add tests so we have 100% coverage
- fix Stub.port() bug when passing in a port
